### PR TITLE
Fix number formatting for thousands

### DIFF
--- a/lib/utils/number_util.dart
+++ b/lib/utils/number_util.dart
@@ -8,7 +8,7 @@ class NumberUtil {
     } else if (n >= 1000000) {
       n /= 1000000;
       return "${n.toStringAsFixed(2)}M";
-    } else if (n >= 10000) {
+    } else if (n >= 1000) {
       n /= 1000;
       return "${n.toStringAsFixed(2)}K";
     } else {


### PR DESCRIPTION
## Summary
- correct threshold for showing values in `K` units

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df8d08144832a91e6cd2dc5cdbc1b